### PR TITLE
Add a debug UI that lets us load/reload levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/*.rs.bk
 *.swp
+
+imgui.ini

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,7 @@ dependencies = [
  "imgui-winit-support 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "specs 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiled 0.8.0 (git+https://github.com/mystal/rs-tiled?branch=dev)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "ggez"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/mystal/ggez?branch=dev#722a8c887dbbcac63bb93598edb5a5051aef8293"
 dependencies = [
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -861,6 +861,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "imgui"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "imgui-gfx-renderer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gfx 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "imgui-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "imgui-winit-support"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "imgui 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "inflate"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,7 +920,13 @@ dependencies = [
 name = "isengard-returns"
 version = "0.1.0"
 dependencies = [
- "ggez 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx_core 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx_device_gl 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ggez 0.5.1 (git+https://github.com/mystal/ggez?branch=dev)",
+ "imgui 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui-gfx-renderer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui-winit-support 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "specs 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiled 0.8.0 (git+https://github.com/mystal/rs-tiled?branch=dev)",
 ]
@@ -2346,7 +2391,7 @@ dependencies = [
 "checksum gfx_device_gl 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3fdb9c21d057f32d5a9fc7b8737a28e09a93006a095e0a129723b424cffd2003"
 "checksum gfx_gl 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8525888d909a6424b04f9136976f07a85fc1f3704555c1a73897e258326c8319"
 "checksum gfx_window_glutin 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f415d3534e6ea92f3ded1683e9e00592a76e2e67050e33244bb507719a211eb2"
-"checksum ggez 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2a76347431050a0b4e1a925124cdcde614b628260093bb52560d9c6b48435336"
+"checksum ggez 0.5.1 (git+https://github.com/mystal/ggez?branch=dev)" = "<none>"
 "checksum gif 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "86c2f2b597d6e05c86ee5947b2223bda468fe8dad3e88e2a6520869322aaf568"
 "checksum gilrs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b012698ad05fc2b88cdf38cd4bc1c94f7fea862ea26cef36aee03de877ef028b"
 "checksum gilrs-core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "410f453995157b78c4bb941e5dffd6d9f7d7976ce60899c052b340e61e381ccd"
@@ -2365,6 +2410,10 @@ dependencies = [
 "checksum hibitset 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "47e7292fd9f7fe89fa35c98048f2d0a69b79ed243604234d18f6f8a1aa6f408d"
 "checksum hound 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a164bb2ceaeff4f42542bdb847c41517c78a60f5649671b2a07312b6e117549"
 "checksum image 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)" = "663a975007e0b49903e2e8ac0db2c432c465855f2d65f17883ba1476e85f0b42"
+"checksum imgui 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0e137a2e2843161f2de8b7acda2e79e60cc67ecb539303fc65b5d76f38d9dc7"
+"checksum imgui-gfx-renderer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09e6a49e7ef84b17a3882298a2f2cc37e43e24884cedb10df859453a8998e526"
+"checksum imgui-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5efa427def85658779af5061dd125921aa3269cc968b5a8856450ddf950d57f"
+"checksum imgui-winit-support 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd9626646610c5dc5639b33b42de59b6fc2e7913aae483a68b29c0039f379390"
 "checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 "checksum io-kit-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f21dcc74995dd4cd090b147e79789f8d65959cbfb5f0b118002db869ea3bd0a0"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Gabriel Martinez <reitaka@gmail.com>",
 ggez = { git = "https://github.com/mystal/ggez", branch = "dev" }
 specs = { version = "0.15", features = ["specs-derive"] }
 tiled = { git = "https://github.com/mystal/rs-tiled", branch = "dev" }
+walkdir = "2"
 
 # TODO: Put gfx and imgui dependencies behind a feature group.
 gfx = "0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,15 @@ authors = ["Gabriel Martinez <reitaka@gmail.com>",
            "Sahil Khanna <sahilsan@gmail.com>"]
 
 [dependencies]
+#ggez = "0.5"
+ggez = { git = "https://github.com/mystal/ggez", branch = "dev" }
+specs = { version = "0.15", features = ["specs-derive"] }
+tiled = { git = "https://github.com/mystal/rs-tiled", branch = "dev" }
+
 # TODO: Put gfx and imgui dependencies behind a feature group.
 gfx = "0.18"
 gfx_core = "0.9"
 gfx_device_gl = "0.16"
-#ggez = "0.5"
-ggez = { git = "https://github.com/mystal/ggez", branch = "dev" }
 imgui = "0.1"
 imgui-gfx-renderer = "0.1"
 imgui-winit-support = "0.1"
-specs = { version = "0.15", features = ["specs-derive"] }
-tiled = { git = "https://github.com/mystal/rs-tiled", branch = "dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,14 @@ authors = ["Gabriel Martinez <reitaka@gmail.com>",
            "Sahil Khanna <sahilsan@gmail.com>"]
 
 [dependencies]
-ggez = "0.5.0-rc.2"
+# TODO: Put gfx and imgui dependencies behind a feature group.
+gfx = "0.18"
+gfx_core = "0.9"
+gfx_device_gl = "0.16"
+#ggez = "0.5"
+ggez = { git = "https://github.com/mystal/ggez", branch = "dev" }
+imgui = "0.1"
+imgui-gfx-renderer = "0.1"
+imgui-winit-support = "0.1"
 specs = { version = "0.15", features = ["specs-derive"] }
 tiled = { git = "https://github.com/mystal/rs-tiled", branch = "dev" }

--- a/assets/levels/test2.tmx
+++ b/assets/levels/test2.tmx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="20" height="15" tilewidth="40" tileheight="40" infinite="0" nextlayerid="5" nextobjectid="11">
+ <tileset firstgid="1" source="grid tileset.tsx"/>
+ <tileset firstgid="3" source="grid entities tileset.tsx"/>
+ <layer id="2" name="Grid" width="20" height="15">
+  <data encoding="csv">
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
+</data>
+ </layer>
+ <objectgroup id="4" name="Entities">
+  <object id="1" gid="3" x="560" y="440" width="40" height="40">
+   <properties>
+    <property name="waypoint_id" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="2" gid="5" x="120" y="320" width="40" height="40"/>
+  <object id="3" gid="4" x="200" y="520" width="40" height="40">
+   <properties>
+    <property name="waypoint_id" type="int" value="0"/>
+   </properties>
+  </object>
+  <object id="10" gid="4" x="320" y="400" width="40" height="40">
+   <properties>
+    <property name="waypoint_id" type="int" value="1"/>
+   </properties>
+  </object>
+ </objectgroup>
+</map>

--- a/src/debug_ui.rs
+++ b/src/debug_ui.rs
@@ -1,0 +1,89 @@
+use gfx_core::memory::Typed;
+use ggez::*;
+use ggez::event::winit_event::Event;
+use imgui::{Context as ImguiContext, Io, Ui};
+use imgui_gfx_renderer::{Renderer as ImguiRenderer, Shaders};
+use imgui_winit_support::{HiDpiMode, WinitPlatform};
+
+pub struct DebugUi {
+    imgui: ImguiContext,
+    platform: WinitPlatform,
+    renderer: ImguiRenderer<gfx::format::Rgba8, gfx_device_gl::Resources>,
+}
+
+impl DebugUi {
+    pub fn new(ctx: &mut Context) -> Self {
+        // Initialize Dear Imgui and its GFX renderer.
+        let mut imgui = ImguiContext::create();
+        // TODO: Set imgui.ini file path.
+        let mut platform = WinitPlatform::init(&mut imgui);
+        platform.attach_window(imgui.io_mut(), graphics::window(ctx), HiDpiMode::Rounded);
+        let renderer = {
+            let (factory, device, _encoder, _depth_stencil_view, _render_target_view) =
+                graphics::gfx_objects(ctx);
+            let version = device.get_info().shading_language;
+            let shaders = if version.is_embedded {
+                if version.major >= 3 {
+                    Shaders::GlSlEs300
+                } else {
+                    Shaders::GlSlEs100
+                }
+            } else if version.major >= 4 {
+                Shaders::GlSl400
+            } else if version.major >= 3 {
+                if version.minor >= 2 {
+                    Shaders::GlSl150
+                } else {
+                    Shaders::GlSl130
+                }
+            } else {
+                Shaders::GlSl110
+            };
+            ImguiRenderer::init(&mut imgui, factory, shaders)
+                .expect("Could not initialize imgui_gfx_renderer::Renderer")
+        };
+
+        Self {
+            imgui,
+            platform,
+            renderer,
+        }
+    }
+
+    pub fn handle_event(&mut self, ctx: &Context, event: &Event) {
+        self.platform.handle_event(self.imgui.io_mut(), graphics::window(ctx), event);
+    }
+
+    pub fn prepare_frame(&mut self, ctx: &Context) -> GameResult {
+        self.platform.prepare_frame(self.imgui.io_mut(), graphics::window(ctx))
+            .map_err(|err| GameError::WindowError(err))?;
+        // NOTE: Setting delta time directly instead of calling io_mut().update_delta_time().
+        self.imgui.io_mut().delta_time = timer::duration_to_f64(timer::delta(ctx)) as f32;
+
+        Ok(())
+    }
+
+    pub fn draw_ui<F>(&mut self, ctx: &mut Context, func: F)
+        where F: FnOnce(&Ui)
+    {
+        // Build our Dear Imgui UI elements.
+        let ui = self.imgui.frame();
+
+        func(&ui);
+
+        // Render our Dear Imgui UI elements.
+        self.platform.prepare_render(&ui, graphics::window(ctx));
+        let ui_draw_data = ui.render();
+        {
+            let (factory, _device, encoder, _depth_stencil_view, render_target_view) =
+                graphics::gfx_objects(ctx);
+            let mut target = gfx_core::handle::RenderTargetView::new(render_target_view);
+            self.renderer.render(factory, encoder, &mut target, ui_draw_data)
+                .expect("Could not render Dear Imgui UI");
+        }
+    }
+
+    pub fn io(&self) -> &Io {
+        self.imgui.io()
+    }
+}

--- a/src/debug_ui.rs
+++ b/src/debug_ui.rs
@@ -77,6 +77,9 @@ impl DebugUi {
         self.platform.handle_event(self.imgui.io_mut(), graphics::window(ctx), event);
     }
 
+    /// Frame preparation method.
+    ///
+    /// Call this before calling `draw_ui`.
     pub fn prepare_frame(&mut self, ctx: &Context) -> GameResult {
         self.platform.prepare_frame(self.imgui.io_mut(), graphics::window(ctx))
             .map_err(|err| GameError::WindowError(err))?;

--- a/src/debug_ui.rs
+++ b/src/debug_ui.rs
@@ -1,3 +1,5 @@
+pub use imgui::im_str;
+
 use gfx_core::memory::Typed;
 use ggez::*;
 use ggez::event::winit_event::Event;
@@ -13,6 +15,9 @@ pub struct DebugUi {
 
 impl DebugUi {
     pub fn new(ctx: &mut Context) -> Self {
+        // NOTE: This init code is based on:
+        // https://github.com/Gekkio/imgui-rs/blob/v0.1.0/imgui-gfx-examples/examples/support/mod.rs
+
         // Initialize Dear Imgui and its GFX renderer.
         let mut imgui = ImguiContext::create();
         // TODO: Set imgui.ini file path.
@@ -68,7 +73,6 @@ impl DebugUi {
     {
         // Build our Dear Imgui UI elements.
         let ui = self.imgui.frame();
-
         func(&ui);
 
         // Render our Dear Imgui UI elements.

--- a/src/debug_ui.rs
+++ b/src/debug_ui.rs
@@ -21,13 +21,14 @@ impl DebugUi {
         // Initialize Dear Imgui and its GFX renderer.
         let mut imgui = ImguiContext::create();
         // Convert Imgui's style colors from sRGB to linear since we're using an sRGB framebuffer.
+        // See: https://github.com/ocornut/imgui/issues/578
         // NOTE: Make sure to do this after loading any themes.
         {
             fn imgui_gamma_to_linear(col: [f32; 4]) -> [f32; 4] {
                 let x = col[0].powf(2.2);
                 let y = col[1].powf(2.2);
                 let z = col[2].powf(2.2);
-                let w = 1.0 - (1.0 - col[3]).powf(2.2);
+                let w = col[3];
                 [x, y, z, w]
             }
 

--- a/src/debug_ui.rs
+++ b/src/debug_ui.rs
@@ -20,6 +20,23 @@ impl DebugUi {
 
         // Initialize Dear Imgui and its GFX renderer.
         let mut imgui = ImguiContext::create();
+        // Convert Imgui's style colors from sRGB to linear since we're using an sRGB framebuffer.
+        // NOTE: Make sure to do this after loading any themes.
+        {
+            fn imgui_gamma_to_linear(col: [f32; 4]) -> [f32; 4] {
+                let x = col[0].powf(2.2);
+                let y = col[1].powf(2.2);
+                let z = col[2].powf(2.2);
+                let w = 1.0 - (1.0 - col[3]).powf(2.2);
+                [x, y, z, w]
+            }
+
+            let style = imgui.style_mut();
+            for col in 0..style.colors.len() {
+                style.colors[col] = imgui_gamma_to_linear(style.colors[col]);
+            }
+        }
+
         // TODO: Set imgui.ini file path.
         let mut platform = WinitPlatform::init(&mut imgui);
         platform.attach_window(imgui.io_mut(), graphics::window(ctx), HiDpiMode::Rounded);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,15 @@
 use std::f32;
 
+use gfx_core::memory::Typed;
 use ggez::*;
 use ggez::input::{
     keyboard::{KeyCode, KeyMods},
     mouse::MouseButton,
 };
 use ggez::nalgebra::Point2;
+use imgui::Context as ImguiContext;
+use imgui_gfx_renderer::{Renderer as ImguiRenderer, Shaders};
+use imgui_winit_support::{HiDpiMode, WinitPlatform};
 use specs::prelude::*;
 
 use components::*;
@@ -21,9 +25,16 @@ mod resources;
 mod systems;
 
 struct State<'a, 'b> {
+    // Game state.
     world: World,
     dispatcher: Dispatcher<'a, 'b>,
     reload_level: bool,
+
+    // Dear Imgui state.
+    // TODO: Put these in their own struct and file to simplify things.
+    imgui: ImguiContext,
+    platform: WinitPlatform,
+    renderer: ImguiRenderer<gfx::format::Rgba8, gfx_device_gl::Resources>,
 }
 
 impl<'a, 'b> ggez::event::EventHandler for State<'a, 'b> {
@@ -80,6 +91,11 @@ impl<'a, 'b> ggez::event::EventHandler for State<'a, 'b> {
         }
     }
 
+    fn raw_winit_event(&mut self, ctx: &mut Context, event: &event::winit_event::Event) {
+        // NOTE: This is called before any other event handlers.
+        self.platform.handle_event(self.imgui.io_mut(), graphics::window(ctx), event);
+    }
+
     fn update(&mut self, ctx: &mut Context) -> GameResult<()> {
         // Call maintain to update all entities created via input events.
         self.world.maintain();
@@ -112,6 +128,12 @@ impl<'a, 'b> ggez::event::EventHandler for State<'a, 'b> {
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {
+        // Set up Dear Imgui for this frame.
+        self.platform.prepare_frame(self.imgui.io_mut(), graphics::window(ctx))
+            .map_err(|err| GameError::WindowError(err))?;
+        // NOTE: Setting delta time directly instead of calling io_mut().update_delta_time().
+        self.imgui.io_mut().delta_time = timer::duration_to_f64(timer::delta(ctx)) as f32;
+
         graphics::clear(ctx, graphics::BLACK);
 
         let system_data: (
@@ -267,13 +289,35 @@ impl<'a, 'b> ggez::event::EventHandler for State<'a, 'b> {
             _ => {}
         }
 
+        // Build our Dear Imgui UI elements.
+        let ui = self.imgui.frame();
+        let mut opened = false;
+        ui.show_demo_window(&mut opened);
+
+        // Render our Dear Imgui UI elements.
+        self.platform.prepare_render(&ui, graphics::window(ctx));
+        let ui_draw_data = ui.render();
+        {
+            let (factory, _device, encoder, _depth_stencil_view, render_target_view) =
+                graphics::gfx_objects(ctx);
+            let mut target = gfx_core::handle::RenderTargetView::new(render_target_view);
+            self.renderer.render(factory, encoder, &mut target, ui_draw_data)
+                .expect("Could not render Dear Imgui UI");
+        }
+        // TODO: Pipe into the GFX Renderer.
+        // render the UI with a renderer
+        //let draw_data = ui.render();
+        // renderer.render(..., draw_data).expect("UI rendering failed");
+
+        // NOTE: Add any over-UI rendering here.
+
         graphics::present(ctx)?;
         Ok(())
     }
 }
 
 impl<'a, 'b> State<'a, 'b> {
-    fn new(_ctx: &mut Context) -> GameResult<Self> {
+    fn new(ctx: &mut Context) -> GameResult<Self> {
         // Set up the specs world.
         let mut world = World::new();
         world.register::<Transform>();
@@ -297,10 +341,44 @@ impl<'a, 'b> State<'a, 'b> {
         // Load the level!
         level::load_level(&mut world);
 
+        // Initialize Dear Imgui and its GFX renderer.
+        let mut imgui = ImguiContext::create();
+        // TODO: Set imgui.ini file path.
+        let mut platform = WinitPlatform::init(&mut imgui);
+        platform.attach_window(imgui.io_mut(), graphics::window(ctx), HiDpiMode::Rounded);
+        let renderer = {
+            let (factory, device, _encoder, _depth_stencil_view, _render_target_view) =
+                graphics::gfx_objects(ctx);
+            let version = device.get_info().shading_language;
+            let shaders = if version.is_embedded {
+                if version.major >= 3 {
+                    Shaders::GlSlEs300
+                } else {
+                    Shaders::GlSlEs100
+                }
+            } else if version.major >= 4 {
+                Shaders::GlSl400
+            } else if version.major >= 3 {
+                if version.minor >= 2 {
+                    Shaders::GlSl150
+                } else {
+                    Shaders::GlSl130
+                }
+            } else {
+                Shaders::GlSl110
+            };
+            ImguiRenderer::init(&mut imgui, factory, shaders)
+                .expect("Could not initialize imgui_gfx_renderer::Renderer")
+        };
+
         Ok(Self {
             world,
             dispatcher,
             reload_level: false,
+
+            imgui,
+            platform,
+            renderer,
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,11 @@ struct State<'a, 'b> {
 
 impl<'a, 'b> ggez::event::EventHandler for State<'a, 'b> {
     fn mouse_button_down_event(&mut self, _ctx: &mut Context, button: MouseButton, x: f32, y: f32) {
+        // Imgui is taking mouse input, so ignore this click.
+        if self.imgui.io().want_capture_mouse {
+            return;
+        }
+
         // TODO: Move this to a system.
         // If the player clicks on an open spot on the grid and has enough bits, then build a tower.
         if button == MouseButton::Left && *self.world.read_resource::<PlayState>() == PlayState::Play &&
@@ -78,6 +83,11 @@ impl<'a, 'b> ggez::event::EventHandler for State<'a, 'b> {
     }
 
     fn key_down_event(&mut self, ctx: &mut Context, keycode: KeyCode, _keymods: KeyMods, repeat: bool) {
+        // Imgui is taking keyboard input, so ignore this key.
+        if self.imgui.io().want_capture_keyboard {
+            return;
+        }
+
         if repeat {
             return;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use ggez::nalgebra::Point2;
 use specs::prelude::*;
 
 use components::*;
-use debug_ui::DebugUi;
+use debug_ui::*;
 use grid::*;
 use resources::*;
 use systems::*;
@@ -22,13 +22,23 @@ mod rect;
 mod resources;
 mod systems;
 
+#[derive(Clone, Debug)]
+enum LoadLevelRequest {
+    None,
+    Reload,
+    NewLevel(String),
+}
+
 struct State<'a, 'b> {
     // Game state.
     world: World,
     dispatcher: Dispatcher<'a, 'b>,
-    reload_level: bool,
+    current_level: String,
+    level_request: LoadLevelRequest,
 
     debug_ui: DebugUi,
+    // Debug UI state.
+    level_list: Vec<String>,
 }
 
 impl<'a, 'b> ggez::event::EventHandler for State<'a, 'b> {
@@ -91,7 +101,7 @@ impl<'a, 'b> ggez::event::EventHandler for State<'a, 'b> {
         }
 
         if keycode == KeyCode::R {
-            self.reload_level = true;
+            self.level_request = LoadLevelRequest::Reload;
         }
     }
 
@@ -101,12 +111,19 @@ impl<'a, 'b> ggez::event::EventHandler for State<'a, 'b> {
     }
 
     fn update(&mut self, ctx: &mut Context) -> GameResult<()> {
+        // TODO: Watch level directory for changes and update level_list if any files are
+        // added/removed.
+
         // Call maintain to update all entities created via input events.
         self.world.maintain();
 
-        if self.reload_level {
-            level::load_level(&mut self.world);
-            self.reload_level = false;
+        if let LoadLevelRequest::Reload = self.level_request {
+            level::load_level(&self.current_level, &mut self.world);
+            self.level_request = LoadLevelRequest::None;
+        } else if let LoadLevelRequest::NewLevel(level_name) = &self.level_request {
+            level::load_level(level_name, &mut self.world);
+            self.current_level = level_name.clone();
+            self.level_request = LoadLevelRequest::None;
         } else {
             {
                 // Sets the time and updates it
@@ -291,9 +308,30 @@ impl<'a, 'b> ggez::event::EventHandler for State<'a, 'b> {
         }
 
         // Build and draw the debug UI.
+        let level_request = &mut self.level_request;
+        let level_list = &self.level_list;
+        let current_level = &self.current_level;
         self.debug_ui.draw_ui(ctx, |ui| {
-            let mut opened = false;
-            ui.show_demo_window(&mut opened);
+            ui.main_menu_bar(|| {
+                ui.menu(im_str!("Level")).build(|| {
+                    ui.menu(im_str!("Load")).build(|| {
+                        // Populate with list of levels.
+                        for level_name in level_list {
+                            let load_level = ui.menu_item(&im_str!("{}", level_name))
+                                .build();
+                            if load_level {
+                                *level_request = LoadLevelRequest::NewLevel(level_name.clone());
+                            }
+                        }
+                    });
+                    let reload_level = ui.menu_item(&im_str!("Reload \"{}\"", current_level))
+                        //.shortcut(im_str!("CTRL+R"))
+                        .build();
+                    if reload_level {
+                        *level_request = LoadLevelRequest::Reload;
+                    }
+                });
+            });
         });
 
         // NOTE: Add any over-UI rendering here.
@@ -326,17 +364,22 @@ impl<'a, 'b> State<'a, 'b> {
         dispatcher.setup(&mut world);
 
         // Load the level!
-        level::load_level(&mut world);
+        let start_level = "test";
+        level::load_level(start_level, &mut world);
 
         // Initialize the debug UI.
         let debug_ui = DebugUi::new(ctx);
 
+        let level_list = level::find_levels();
+
         Ok(Self {
             world,
             dispatcher,
-            reload_level: false,
+            current_level: start_level.to_owned(),
+            level_request: LoadLevelRequest::None,
 
             debug_ui,
+            level_list,
         })
     }
 }


### PR DESCRIPTION
This is a big review with a few changes:
* Integrate Dear Imgui for debug UIs.
* Switch to using our own branch of `ggez` to expose raw `winit` events for Dear Imgui to consume.
* Use `gfx` to render the Dear Imgui elements. This mostly uses `ggez`'s rendering infrastructure, but I had to pull in some `gfx` dependencies to make it fully work.
* Use `walkdir` to get a list of levels in our assets directory.